### PR TITLE
Handle special keys correctly

### DIFF
--- a/lib/rurses.rb
+++ b/lib/rurses.rb
@@ -35,10 +35,12 @@ module Rurses
 
   def get_key
     case (char = curses.getch)
-    when curses::KeyDefs::KEY_CODE_YES..curses::KeyDefs::KEY_MAX
+    when !SPECIAL_KEYS[char].nil?
       SPECIAL_KEYS[char]
     when curses::ERR
       nil
+    when 127
+      :BACKSPACE
     else
       char.chr
     end


### PR DESCRIPTION
Hi James,

I realize this repo is ancient, but I'm building an ncurses app in ruby and found your library to be so useful.

I found that `Rurses.get_key` was not handling special keys correctly - this PR fixes that. Additionally, I found that `ffi-ncurses` lacks support for the right backspace key code (127) - but they're library attempts to be a pure wrapper for ncurses, so I figured that `Rurses` is a better spot to add that support in.

If you are no longer maintaining (or interested in maintaining) this gem or releasing a new version do let me know, I would be open to taking it over. This ncurses project I'm building will take me a couple months and I will likely find more abstractions to add to the gem - like perhaps a better layout management mechanism.

Alternatively - I could create a new gem that forks this one, but I would prefer not to do that.

Thanks,
Vidur